### PR TITLE
Custom tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,15 @@ from the following environment variables:
 * SLACK_WEBHOOK_HOST - host name of the webhook's URL such as hooks.slack.com
 * SLACK_WEBHOOK_PATH - request path
 
-For lambda deployment automation, using environment variables may not be the
-best solution.  Also consider using an additional JSON file, stored external
-to the repo.
+Set these values in `config.env.production` in the root of the repo.
+
+    ```javascript
+    SLACK_WEBHOOK_HOST = "hooks.slack.com
+    SLACK_WEBHOOK_PATH = "/services/###############/##############"
+    ```
+
+During initialization, the contents of this file will automatically be loaded
+into the environment.
 
 ## Autoscale AWS DynamoDB using an AWS Lambda function
 

--- a/README.md
+++ b/README.md
@@ -179,7 +179,12 @@ A breakdown of the configuration behaviour is as follows:
 ## Strategy Settings
 
 The strategy settings described above uses a simple schema which applies to both Read/Write and to
-both the Increment/Decrement.  Using the options below many different strategies can be constructed:
+both the Increment/Decrement.  For an Increment, if more than one option is 
+specified, the maximum of the specified options is used.  For a Decrement, the
+minimum of the specified options is used.  The Increment/Decrement is bounded
+by the Max/Min, respectively.  See the example, in the [Configuration](#configuration) 
+section, for a more concrete illustration of how the different options work 
+together.  Using the options below many different strategies can be constructed:
 - ReadCapacity.Min : (Optional) Define a minimum allowed capacity, otherwise 1
 - ReadCapacity.Max : (Optional) Define a maximum allowed capacity, otherwise unlimited
 - ReadCapacity.Increment : (Optional) Defined an increment strategy

--- a/README.md
+++ b/README.md
@@ -1,5 +1,52 @@
 # dynamodb-lambda-autoscale
-**Autoscale AWS DynamoDB using an AWS Lambda function**
+
+## Boss Specific Files
+
+This node project has been adapted specifically for the Boss datastore. Boss
+table specific auto-scale strategies are placed in the following two files.
+
+### ./configuration/BossTableConfig.json
+
+This file maps DynamoDB table names to specific auto-scaling configurations in
+BossProvisioners.json.  Example JSON:
+
+```javascript
+{
+    "table1": "strategy2",
+    "table2": "strategy1",
+    "table3": "strategy2"
+}
+```
+
+### ./configuration/BossProvisioners.json
+
+This file describes all the auto-scaling strategies available.  The strategy
+object used in the example is defined [below](#Strategy-Settings). Example
+JSON:
+
+```javascript
+{
+    "strategy1": { strategy_object },
+    "strategy2": { strategy_object },
+    .
+    .
+    "strategyn": { strategy_object }
+}
+```
+
+## Slack integration
+
+Table update notifications are published to Slack.  Slack settings are taken
+from the following environment variables:
+
+* SLACK_WEBHOOK_HOST - host name of the webhook's URL such as hooks.slack.com
+* SLACK_WEBHOOK_PATH - request path
+
+For lambda deployment automation, using environment variables may not be the
+best solution.  Also consider using an additional JSON file, stored external
+to the repo.
+
+## Autoscale AWS DynamoDB using an AWS Lambda function
 
 + 5 minute setup process
 + Serverless design
@@ -84,7 +131,7 @@ configuration.  Please see the respective websites for advantages / reasons.
 3. Create a AWS Lambda function
   1. Skip the pre defined functions step
   2. Set the name to 'DynamoDBLambdaAutoscale'
-  3. Set the runtime to 'Node.js 4.3'
+  3. Set the runtime to 'Node.js 6.x'
   4. Select upload a zip file and select 'dist.zip' which you created earlier
   5. Set the handler to 'index.handler'
   6. Set the Role to 'DynamoDBLambdaAutoscale'

--- a/README.md
+++ b/README.md
@@ -8,16 +8,24 @@ table specific auto-scale strategies are placed in the following two files.
 ### ./configuration/BossTableConfig.json
 
 This file maps DynamoDB table names to specific auto-scaling configurations in
-BossProvisioners.json.  During deployment, the table names should be
-auto-generated according to the stack used.  Example JSON:
+BossProvisioners.json.  **DO NOT** use the full name of the table.  Only use 
+the first part of the table's name such as `bossmeta`.  At runtime, the domain
+name will be appended to each table's name so that the table is properly named.
+Example JSON:
 
-```javascript
-{
-    "table1": "strategy2",
-    "table2": "strategy1",
-    "table3": "strategy2"
-}
-```
+    ```javascript
+    {
+        "bossmeta": "strategy2",
+        "s3index": "strategy1",
+        "tileindex": "strategy2"
+    }
+    ```
+
+In `config.env.production` in the root of the repo, set the domain name:
+
+    ```javascript
+    VPC_DOMAIN = "production.boss"
+    ```
 
 ### ./configuration/BossProvisioners.json
 
@@ -25,15 +33,15 @@ This file describes all the auto-scaling strategies available.  The strategy
 object used in the example is defined [below](#Strategy-Settings). Example
 JSON:
 
-```javascript
-{
-    "strategy1": { strategy_object },
-    "strategy2": { strategy_object },
-    .
-    .
-    "strategyn": { strategy_object }
-}
-```
+    ```javascript
+    {
+        "strategy1": { strategy_object },
+        "strategy2": { strategy_object },
+        .
+        .
+        "strategyn": { strategy_object }
+    }
+    ```
 
 ## Slack integration
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ table specific auto-scale strategies are placed in the following two files.
 ### ./configuration/BossTableConfig.json
 
 This file maps DynamoDB table names to specific auto-scaling configurations in
-BossProvisioners.json.  Example JSON:
+BossProvisioners.json.  During deployment, the table names should be
+auto-generated according to the stack used.  Example JSON:
 
 ```javascript
 {

--- a/src/App.js
+++ b/src/App.js
@@ -16,6 +16,25 @@ export default class App {
   constructor() {
     this._provisioner = new Provisioner();
     this._capacityCalculator = new CapacityCalculator();
+    this._checkEnvVariables();
+  }
+
+  // These environment variables are required.
+  _checkEnvVariables() {
+    if(!('VPC_DOMAIN' in process.env)) {
+      log('Error: VPC_DOMAIN environment variable not set.');
+      throw(new Error('VPC_DOMAIN environment variable not set.'));
+    }
+
+    if(!('SLACK_WEBHOOK_HOST' in process.env)) {
+      log('Error: SLACK_WEBHOOK_HOST environment variable not set.');
+      throw(new Error('SLACK_WEBHOOK_HOST environment variable not set.'));
+    }
+
+    if(!('SLACK_WEBHOOK_PATH' in process.env)) {
+      log('Error: SLACK_WEBHOOK_PATH environment variable not set.');
+      throw(new Error('SLACK_WEBHOOK_PATH environment variable not set.'));
+    }
   }
 
   async runAsync(event: any, context: any): Promise<void> {

--- a/src/App.js
+++ b/src/App.js
@@ -52,9 +52,7 @@ export default class App {
 
     // Send updates to Slack
     if(tableUpdateRequests.length > 0) {
-      let msg = JSON.stringify(
-        { 'text': metricStr, 'channel': process.env.SLACK_CHANNEL },
-        null, json.padding);
+      let msg = JSON.stringify({'text': metricStr}, null, json.padding);
 
       let options = {
         hostname: process.env.SLACK_WEBHOOK_HOST,

--- a/src/App.js
+++ b/src/App.js
@@ -71,7 +71,8 @@ export default class App {
 
     // Send updates to Slack
     if(tableUpdateRequests.length > 0) {
-      let msg = JSON.stringify({'text': metricStr}, null, json.padding);
+      // $FlowIgnore
+      let msg = JSON.stringify({'text': process.env.VPC_DOMAIN + ':\n' + metricStr}, null, json.padding);
 
       let options = {
         hostname: process.env.SLACK_WEBHOOK_HOST,

--- a/src/configuration/BossProvisioners.json
+++ b/src/configuration/BossProvisioners.json
@@ -58,5 +58,305 @@
             }
           }
         }
+    },
+    "bossmeta_cfg": {
+        "ReadCapacity": {
+          "Min": 5,
+          "Max": 75,
+          "Increment": {
+            "When": {
+              "UtilisationIsAbovePercent": 75,
+              "ThrottledEventsPerMinuteIsAbove": 25
+            },
+            "By": {
+              "Units": 3,
+              "ProvisionedPercent": 30,
+              "ThrottledEventsWithMultiplier": 0.7
+            },
+            "To": {
+              "ConsumedPercent": 130
+            }
+          },
+          "Decrement": {
+            "When": {
+              "UtilisationIsBelowPercent": 30,
+              "AfterLastIncrementMinutes": 60,
+              "AfterLastDecrementMinutes": 60,
+              "UnitAdjustmentGreaterThan": 5
+            },
+            "To": {
+              "ConsumedPercent": 100
+            }
+          }
+        },
+        "WriteCapacity": {
+          "Min": 5,
+          "Max": 75,
+          "Increment": {
+            "When": {
+              "UtilisationIsAbovePercent": 75,
+              "ThrottledEventsPerMinuteIsAbove": 25
+            },
+            "By": {
+              "Units": 3,
+              "ProvisionedPercent": 30,
+              "ThrottledEventsWithMultiplier": 0.7
+            },
+            "To": {
+              "ConsumedPercent": 130
+            }
+          },
+          "Decrement": {
+            "When": {
+              "UtilisationIsBelowPercent": 30,
+              "AfterLastIncrementMinutes": 60,
+              "AfterLastDecrementMinutes": 60,
+              "UnitAdjustmentGreaterThan": 5
+            },
+            "To": {
+              "ConsumedPercent": 100
+            }
+          }
+        }
+    },
+    "idCount_cfg": {
+        "ReadCapacity": {
+          "Min": 5,
+          "Max": 50,
+          "Increment": {
+            "When": {
+              "UtilisationIsAbovePercent": 75,
+              "ThrottledEventsPerMinuteIsAbove": 25
+            },
+            "By": {
+              "Units": 3,
+              "ProvisionedPercent": 30,
+              "ThrottledEventsWithMultiplier": 0.7
+            },
+            "To": {
+              "ConsumedPercent": 130
+            }
+          },
+          "Decrement": {
+            "When": {
+              "UtilisationIsBelowPercent": 30,
+              "AfterLastIncrementMinutes": 60,
+              "AfterLastDecrementMinutes": 60,
+              "UnitAdjustmentGreaterThan": 5
+            },
+            "To": {
+              "ConsumedPercent": 100
+            }
+          }
+        },
+        "WriteCapacity": {
+          "Min": 10,
+          "Max": 500,
+          "Increment": {
+            "When": {
+              "UtilisationIsAbovePercent": 75,
+              "ThrottledEventsPerMinuteIsAbove": 25
+            },
+            "By": {
+              "Units": 3,
+              "ProvisionedPercent": 30,
+              "ThrottledEventsWithMultiplier": 0.7
+            },
+            "To": {
+              "ConsumedPercent": 130
+            }
+          },
+          "Decrement": {
+            "When": {
+              "UtilisationIsBelowPercent": 30,
+              "AfterLastIncrementMinutes": 60,
+              "AfterLastDecrementMinutes": 60,
+              "UnitAdjustmentGreaterThan": 5
+            },
+            "To": {
+              "ConsumedPercent": 100
+            }
+          }
+        }
+    },
+    "idIndex_cfg": {
+        "ReadCapacity": {
+          "Min": 25,
+          "Max": 250,
+          "Increment": {
+            "When": {
+              "UtilisationIsAbovePercent": 75,
+              "ThrottledEventsPerMinuteIsAbove": 25
+            },
+            "By": {
+              "Units": 3,
+              "ProvisionedPercent": 30,
+              "ThrottledEventsWithMultiplier": 0.7
+            },
+            "To": {
+              "ConsumedPercent": 130
+            }
+          },
+          "Decrement": {
+            "When": {
+              "UtilisationIsBelowPercent": 30,
+              "AfterLastIncrementMinutes": 60,
+              "AfterLastDecrementMinutes": 60,
+              "UnitAdjustmentGreaterThan": 5
+            },
+            "To": {
+              "ConsumedPercent": 100
+            }
+          }
+        },
+        "WriteCapacity": {
+          "Min": 50,
+          "Max": 35000,
+          "Increment": {
+            "When": {
+              "UtilisationIsAbovePercent": 75,
+              "ThrottledEventsPerMinuteIsAbove": 25
+            },
+            "By": {
+              "Units": 3,
+              "ProvisionedPercent": 50,
+              "ThrottledEventsWithMultiplier": 0.7
+            },
+            "To": {
+              "ConsumedPercent": 200
+            }
+          },
+          "Decrement": {
+            "When": {
+              "UtilisationIsBelowPercent": 30,
+              "AfterLastIncrementMinutes": 60,
+              "AfterLastDecrementMinutes": 60,
+              "UnitAdjustmentGreaterThan": 5
+            },
+            "To": {
+              "ConsumedPercent": 100
+            }
+          }
+        }
+    },
+    "s3index_cfg": {
+        "ReadCapacity": {
+          "Min": 25,
+          "Max": 5000,
+          "Increment": {
+            "When": {
+              "UtilisationIsAbovePercent": 75,
+              "ThrottledEventsPerMinuteIsAbove": 25
+            },
+            "By": {
+              "Units": 3,
+              "ProvisionedPercent": 30,
+              "ThrottledEventsWithMultiplier": 0.7
+            },
+            "To": {
+              "ConsumedPercent": 130
+            }
+          },
+          "Decrement": {
+            "When": {
+              "UtilisationIsBelowPercent": 30,
+              "AfterLastIncrementMinutes": 60,
+              "AfterLastDecrementMinutes": 60,
+              "UnitAdjustmentGreaterThan": 5
+            },
+            "To": {
+              "ConsumedPercent": 100
+            }
+          }
+        },
+        "WriteCapacity": {
+          "Min": 25,
+          "Max": 5000,
+          "Increment": {
+            "When": {
+              "UtilisationIsAbovePercent": 75,
+              "ThrottledEventsPerMinuteIsAbove": 25
+            },
+            "By": {
+              "Units": 3,
+              "ProvisionedPercent": 30,
+              "ThrottledEventsWithMultiplier": 0.7
+            },
+            "To": {
+              "ConsumedPercent": 130
+            }
+          },
+          "Decrement": {
+            "When": {
+              "UtilisationIsBelowPercent": 30,
+              "AfterLastIncrementMinutes": 60,
+              "AfterLastDecrementMinutes": 60,
+              "UnitAdjustmentGreaterThan": 5
+            },
+            "To": {
+              "ConsumedPercent": 100
+            }
+          }
+        }
+    },
+    "tileindex_cfg": {
+        "ReadCapacity": {
+          "Min": 5,
+          "Max": 5000,
+          "Increment": {
+            "When": {
+              "UtilisationIsAbovePercent": 75,
+              "ThrottledEventsPerMinuteIsAbove": 25
+            },
+            "By": {
+              "Units": 3,
+              "ProvisionedPercent": 30,
+              "ThrottledEventsWithMultiplier": 0.7
+            },
+            "To": {
+              "ConsumedPercent": 130
+            }
+          },
+          "Decrement": {
+            "When": {
+              "UtilisationIsBelowPercent": 30,
+              "AfterLastIncrementMinutes": 60,
+              "AfterLastDecrementMinutes": 60,
+              "UnitAdjustmentGreaterThan": 5
+            },
+            "To": {
+              "ConsumedPercent": 100
+            }
+          }
+        },
+        "WriteCapacity": {
+          "Min": 5,
+          "Max": 5000,
+          "Increment": {
+            "When": {
+              "UtilisationIsAbovePercent": 75,
+              "ThrottledEventsPerMinuteIsAbove": 25
+            },
+            "By": {
+              "Units": 3,
+              "ProvisionedPercent": 30,
+              "ThrottledEventsWithMultiplier": 0.7
+            },
+            "To": {
+              "ConsumedPercent": 130
+            }
+          },
+          "Decrement": {
+            "When": {
+              "UtilisationIsBelowPercent": 30,
+              "AfterLastIncrementMinutes": 60,
+              "AfterLastDecrementMinutes": 60,
+              "UnitAdjustmentGreaterThan": 5
+            },
+            "To": {
+              "ConsumedPercent": 100
+            }
+          }
+        }
     }
 }

--- a/src/configuration/BossProvisioners.json
+++ b/src/configuration/BossProvisioners.json
@@ -1,0 +1,62 @@
+{
+    "default": {
+        "ReadCapacity": {
+          "Min": 1,
+          "Max": 100,
+          "Increment": {
+            "When": {
+              "UtilisationIsAbovePercent": 75,
+              "ThrottledEventsPerMinuteIsAbove": 25
+            },
+            "By": {
+              "Units": 3,
+              "ProvisionedPercent": 30,
+              "ThrottledEventsWithMultiplier": 0.7
+            },
+            "To": {
+              "ConsumedPercent": 130
+            }
+          },
+          "Decrement": {
+            "When": {
+              "UtilisationIsBelowPercent": 30,
+              "AfterLastIncrementMinutes": 60,
+              "AfterLastDecrementMinutes": 60,
+              "UnitAdjustmentGreaterThan": 5
+            },
+            "To": {
+              "ConsumedPercent": 100
+            }
+          }
+        },
+        "WriteCapacity": {
+          "Min": 1,
+          "Max": 100,
+          "Increment": {
+            "When": {
+              "UtilisationIsAbovePercent": 75,
+              "ThrottledEventsPerMinuteIsAbove": 25
+            },
+            "By": {
+              "Units": 3,
+              "ProvisionedPercent": 30,
+              "ThrottledEventsWithMultiplier": 0.7
+            },
+            "To": {
+              "ConsumedPercent": 130
+            }
+          },
+          "Decrement": {
+            "When": {
+              "UtilisationIsBelowPercent": 30,
+              "AfterLastIncrementMinutes": 60,
+              "AfterLastDecrementMinutes": 60,
+              "UnitAdjustmentGreaterThan": 5
+            },
+            "To": {
+              "ConsumedPercent": 100
+            }
+          }
+        }
+    }
+}

--- a/src/configuration/BossTableConfig.json
+++ b/src/configuration/BossTableConfig.json
@@ -1,7 +1,7 @@
 {
-    "bossmeta.giontc1.boss": "default",
-    "idCount.giontc1.boss": "default",
-    "idIndex.giontc1.boss": "default",
-    "s3index.giontc1.boss": "default",
-    "tileindex.giontc1.boss": "default"
+    "bossmeta": "default",
+    "idCount": "default",
+    "idIndex": "default",
+    "s3index": "default",
+    "tileindex": "default"
 }

--- a/src/configuration/BossTableConfig.json
+++ b/src/configuration/BossTableConfig.json
@@ -1,0 +1,7 @@
+{
+    "bossmeta.giontc1.boss": "default",
+    "idCount.giontc1.boss": "default",
+    "idIndex.giontc1.boss": "default",
+    "s3index.giontc1.boss": "default",
+    "tileindex.giontc1.boss": "default"
+}

--- a/src/configuration/BossTableConfig.json
+++ b/src/configuration/BossTableConfig.json
@@ -1,7 +1,7 @@
 {
-    "bossmeta": "default",
-    "idCount": "default",
-    "idIndex": "default",
-    "s3index": "default",
-    "tileindex": "default"
+    "bossmeta": "bossmeta_cfg",
+    "idCount": "idCount_cfg",
+    "idIndex": "idIndex_cfg",
+    "s3index": "s3index_cfg",
+    "tileindex": "tileindex_cfg"
 }

--- a/src/configuration/FixedProvisioner.json
+++ b/src/configuration/FixedProvisioner.json
@@ -1,10 +1,10 @@
 {
   "ReadCapacity": {
-    "Min": 1,
-    "Max": 1
+    "Min": 5,
+    "Max": 5
   },
   "WriteCapacity": {
-    "Min": 1,
-    "Max": 1
+    "Min": 5,
+    "Max": 5
   }
 }


### PR DESCRIPTION
Allows custom auto-scaling of DynamoDB tables according to strategies defined in ./configuration/BossProvisioners.json.  Tables are mapped to strategies in ./configuration/BossTableConfig.json.

After updating tables, a notification is sent to Slack. dynamodb is the name of our existing Slack channel for these updates for the production stack. dynamodb-dev is used for notifications for integration and dev stacks.