### PR TITLE
Use default config when DEV_STACK env var set.

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -35,6 +35,10 @@ export default class App {
       log('Error: SLACK_WEBHOOK_PATH environment variable not set.');
       throw(new Error('SLACK_WEBHOOK_PATH environment variable not set.'));
     }
+
+    if('DEV_STACK' in process.env) {
+      log('DEV_STACK env variable set.  Using non-production autoscale parameters.');
+    } 
   }
 
   async runAsync(event: any, context: any): Promise<void> {

--- a/src/Provisioner.js
+++ b/src/Provisioner.js
@@ -56,6 +56,7 @@ export default class Provisioner extends ProvisionerConfigurableBase {
   // Gets the json settings which control how the specifed table will be autoscaled
   // eslint-disable-next-line no-unused-vars
   getTableConfig(data: TableProvisionedAndConsumedThroughput): ProvisionerConfig {
+    let devStack = 'DEV_STACK' in process.env;
 
     // Option 1 - Default settings for all tables
     // return DefaultProvisioner;
@@ -64,6 +65,10 @@ export default class Provisioner extends ProvisionerConfigurableBase {
     // return data.TableName === 'Table1' ? Climbing : Default;
     if(this._bossTableConfig.hasOwnProperty(data.TableName)) {
       let config = this._bossTableConfig[data.TableName];
+      if(devStack) {
+        // Override configuration when running a developer's stack.
+        config = 'default';
+      }
       if(!provisionerMap.hasOwnProperty(config)) {
         log('WARNING: table: ' + data.TableName + ' specified unknown config: ' + config);
         return FixedProvisioner;

--- a/src/configuration/BossProvisioners.json
+++ b/src/configuration/BossProvisioners.json
@@ -22,7 +22,7 @@
               "UtilisationIsBelowPercent": 30,
               "AfterLastIncrementMinutes": 60,
               "AfterLastDecrementMinutes": 60,
-              "UnitAdjustmentGreaterThan": 5
+              "UnitAdjustmentGreaterThan": 2
             },
             "To": {
               "ConsumedPercent": 100
@@ -51,7 +51,7 @@
               "UtilisationIsBelowPercent": 30,
               "AfterLastIncrementMinutes": 60,
               "AfterLastDecrementMinutes": 60,
-              "UnitAdjustmentGreaterThan": 5
+              "UnitAdjustmentGreaterThan": 2
             },
             "To": {
               "ConsumedPercent": 100


### PR DESCRIPTION
Production min values for DynamoDB tables are too high for little used
dev stacks. Set DEV_STACK environment variable to use config named
"default" which has minimums set to 1.